### PR TITLE
Fix `FindType`

### DIFF
--- a/src/Data/Extensible/Internal.hs
+++ b/src/Data/Extensible/Internal.hs
@@ -184,7 +184,7 @@ type family Head (xs :: [k]) :: k where
 
 -- | FindType types
 type family FindType (x :: k) (xs :: [k]) :: [Nat] where
-  FindType x (x ': xs) = 0 ': FindType x xs
+  FindType x (x ': xs) = 0 ': MapSucc (FindType x xs)
   FindType x (y ': ys) = MapSucc (FindType x ys)
   FindType x '[] = '[]
 


### PR DESCRIPTION
`FindType "foo" '["foo","foo","foo"]` has been evaluated to `'[0,0,0]` instead of `[0,1,2]`.