### PR TITLE
Add fromNullable 

### DIFF
--- a/examples/nullable.hs
+++ b/examples/nullable.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DataKinds, TypeOperators, OverloadedLabels, OverloadedStrings #-}
+import Control.Lens
+import qualified Data.Aeson as J
+import Data.Extensible
+import Data.Maybe (fromMaybe)
+
+type ConfigRec = '[ "columns" >: Int, "language_extensions" >: [String] ]
+
+defaultConfig :: Record ConfigRec
+defaultConfig = #columns @= 80 <: #language_extensions @= [] <: nil
+
+main :: IO ()
+main = do
+  config <- fromNullable defaultConfig <$> readConfig "path/to/config.json"
+  putStrLn $ "columns: " ++ (show $ config ^. #columns)
+  putStrLn $ "language_extensions: " ++ (show $ config ^. #language_extensions)
+
+-- dummy
+readConfig :: FilePath -> IO (Nullable (Field Identity) :* ConfigRec)
+readConfig _path = pure $ fromMaybe vacancy (J.decode "{\"columns\": 100}")

--- a/src/Data/Extensible/Nullable.hs
+++ b/src/Data/Extensible/Nullable.hs
@@ -14,7 +14,8 @@ module Data.Extensible.Nullable (
   , wrench
   , retrench
   , Nullable(..)
-  , mapNullable) where
+  , mapNullable
+  , fromNullable) where
 
 import Control.DeepSeq (NFData)
 import Data.Extensible.Class
@@ -27,6 +28,7 @@ import Data.Typeable (Typeable)
 import Data.Extensible.Wrapper
 import qualified Data.Extensible.Struct as S
 import Data.Profunctor.Unsafe
+import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import Language.Haskell.TH.Lift
 import Language.Haskell.TH (appE, conE)
@@ -77,3 +79,6 @@ wrench xs = mapNullable (flip hlookup xs) `hmap` coinclusion
 retrench :: (Generate ys, xs ⊆ ys) => h :| ys -> Nullable ((:|) h) xs
 retrench (EmbedAt i h) = views (pieceAt i) (mapNullable (`EmbedAt`h)) coinclusion
 {-# INLINE retrench #-}
+
+fromNullable :: h :* xs -> Nullable h :* xs -> h :* xs
+fromNullable def = hmapWithIndex $ \m x -> fromMaybe (hlookup m def) (getNullable x)

--- a/src/Data/Extensible/Nullable.hs
+++ b/src/Data/Extensible/Nullable.hs
@@ -80,5 +80,6 @@ retrench :: (Generate ys, xs ⊆ ys) => h :| ys -> Nullable ((:|) h) xs
 retrench (EmbedAt i h) = views (pieceAt i) (mapNullable (`EmbedAt`h)) coinclusion
 {-# INLINE retrench #-}
 
+-- | 'fromMaybe' for 'Nullable'.
 fromNullable :: h :* xs -> Nullable h :* xs -> h :* xs
 fromNullable def = hmapWithIndex $ \m x -> fromMaybe (hlookup m def) (getNullable x)


### PR DESCRIPTION
`fromNullable` is function to lift to record from nullable record with default value, like `fromMaybe`.

```haskell
fromNullable 
    :: h :* xs           -- default value
    -> Nullable h :* xs 
    -> h :* xs
```

and wrote example: `examples/nullable.hs`

```
$ stack runghc -- examples/nullable.hs 
columns: 100
language_extensions: []
```
