### PR TITLE
display keys on error messages of parseJSON

### DIFF
--- a/src/Data/Extensible/Dictionary.hs
+++ b/src/Data/Extensible/Dictionary.hs
@@ -21,6 +21,7 @@
 module Data.Extensible.Dictionary (library, WrapForall, Instance1, And) where
 import Control.DeepSeq
 import qualified Data.Aeson as J
+import qualified Data.Aeson.Types as J
 #ifdef CASSAVA
 import qualified Data.Csv as Csv
 import qualified Data.ByteString.Char8 as BC
@@ -221,7 +222,7 @@ instance Forall (KeyTargetAre KnownSymbol (Instance1 J.FromJSON h)) xs => J.From
   parseJSON = J.withObject "Object" $ \v -> hgenerateFor
     (Proxy :: Proxy (KeyTargetAre KnownSymbol (Instance1 J.FromJSON h)))
     $ \m -> let k = symbolVal (proxyKeyOf m)
-      in fmap Field $ J.parseJSON $ maybe J.Null id $ HM.lookup (T.pack k) v
+      in fmap Field $ J.prependFailure ("parsing #" ++ k ++ ": ") $ J.parseJSON $ maybe J.Null id $ HM.lookup (T.pack k) v
 
 instance Forall (KeyTargetAre KnownSymbol (Instance1 J.ToJSON h)) xs => J.ToJSON (xs :& Field h) where
   toJSON = J.Object . hfoldlWithIndexFor


### PR DESCRIPTION
error message of `parseJSON` for `Record` type is not display target key:

```
*** Exception: JsonHttpException "Error in $[0]: expected Bool, but encountered Null"
```

debug is very hard. 
So, I think display keys using `Data.Aeson.Types.prependFailure`: 

```
*** Exception: JsonHttpException "Error in $[0]: parsing #channels: parsing #priority: parsing Int failed, expected Number, but encountered Null"
```
