### PR TITLE
Require aeson <2

### DIFF
--- a/extensible.cabal
+++ b/extensible.cabal
@@ -73,7 +73,7 @@ library
     , CPP
     , NoStarIsType
   build-depends:       base >= 4.8 && <5
-    , aeson
+    , aeson <2
     , bytestring
     , comonad
     , constraints


### PR DESCRIPTION
There's a breaking change in aeson 2.0.0.0: it replaced a bunch of uses of `HashMap` with its own `KeyMap`, which breaks us. For now, just set an upper bound on the version of it.