### PR TITLE
Import MonadPlus if mtl >=2.3

### DIFF
--- a/extensible-skeleton/src/Data/Extensible/Effect/Default.hs
+++ b/extensible-skeleton/src/Data/Extensible/Effect/Default.hs
@@ -34,6 +34,9 @@ module Data.Extensible.Effect.Default (
 ) where
 import Control.Applicative
 import Data.Extensible.Effect
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad
+#endif
 import Control.Monad.Except
 import Control.Monad.Catch
 import Control.Monad.Cont


### PR DESCRIPTION
Compile `extensible-skeleton` with `mtl` newer than 2.3.
`mtl` has removed re-exports of `Control.Monad` (which exports `MonadPlus`) since version 2.3,

```
Remove re-exports of Control.Monad, Control.Monad.Fix and Data.Monoid modules 
```
from [ChangeLog](https://hackage.haskell.org/package/mtl-2.3.1/changelog)