### PR TITLE
Support ghc9.8

### DIFF
--- a/extensible-skeleton/src/Data/Extensible/Effect/TH.hs
+++ b/extensible-skeleton/src/Data/Extensible/Effect/TH.hs
@@ -70,13 +70,17 @@ customDecEffects synSet synActions decs = decs >>= \ds -> fmap concat $ forM ds 
           ++ concat dcs
   _ -> fail "mkEffects accepts GADT declaration"
   where
-#if MIN_VERSION_template_haskell(2,17,0)
+#if MIN_VERSION_template_haskell(2,21,0)
+    mkPlainTV n = PlainTV n BndrReq
+#elif MIN_VERSION_template_haskell(2,17,0)
     mkPlainTV n = PlainTV n ()
 #else
     mkPlainTV = PlainTV
 #endif
 
-#if MIN_VERSION_template_haskell(2,17,0)
+#if MIN_VERSION_template_haskell(2,21,0)
+con2Eff :: [TyVarBndr BndrVis] -> Con -> Q ((Name, Type), [Dec])
+#elif MIN_VERSION_template_haskell(2,17,0)
 con2Eff :: [TyVarBndr ()] -> Con -> Q ((Name, Type), [Dec])
 #else
 con2Eff :: [TyVarBndr] -> Con -> Q ((Name, Type), [Dec])
@@ -90,7 +94,9 @@ con2Eff _ p = do
   runIO (print p)
   fail "Unsupported constructor"
 
-#if MIN_VERSION_template_haskell(2,17,0)
+#if MIN_VERSION_template_haskell(2,21,0)
+fromMangledGADT :: [TyVarBndr BndrVis] -> [Type] -> Name -> [(Strict, Type)] -> ((Name, Type), [Dec])
+#elif MIN_VERSION_template_haskell(2,17,0)
 fromMangledGADT :: [TyVarBndr ()] -> [Type] -> Name -> [(Strict, Type)] -> ((Name, Type), [Dec])
 #else
 fromMangledGADT :: [TyVarBndr] -> [Type] -> Name -> [(Strict, Type)] -> ((Name, Type), [Dec])

--- a/extensible.cabal
+++ b/extensible.cabal
@@ -80,7 +80,7 @@ library
     , CPP
     , NoStarIsType
   build-depends:       base >= 4.8 && <5
-    , aeson >= 1.5 && <2.2
+    , aeson >= 1.5 && <2.3
     , bytestring
     , comonad
     , constraints


### PR DESCRIPTION
主にtemplate-haskell 2.21.0以上への対応
https://github.com/fumieval/barbies-th/pull/13 とほぼ同じ変更を行った

以下のバージョンのghcでビルドできることを確認した
* 9.8.2
* 9.6.6
* 9.4.8