### PR TITLE
Support GHC 9.10.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: [ '8.10.7', '9.0.1', '9.2.1' ]
+        ghc: [ '8.10.7', '9.0.1', '9.2.1', '9.10.1' ]
     steps:
     - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2.7.6
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.6'
+        cabal-version: '3.12'
 
     - name: cabal Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       env:
         cache-name: cache-cabal
       with:

--- a/extensible.cabal
+++ b/extensible.cabal
@@ -16,7 +16,7 @@ copyright:           Copyright (c) 2017-2022 Fumiaki Kinoshita
 category:            Data, Records
 build-type:          Simple
 stability:           experimental
-Tested-With:         GHC == 8.10.7, GHC == 9.0.1, GHC == 9.2.1
+Tested-With:         GHC == 8.10.7, GHC == 9.0.1, GHC == 9.2.1, GHC == 9.10.1
 
 extra-source-files:
   examples/*.hs

--- a/src/Data/Extensible/Bits.hs
+++ b/src/Data/Extensible/Bits.hs
@@ -138,7 +138,7 @@ instance FromBits r a => FromBits r (Const a b) where
   fromBits = Const . fromBits
   toBits = toBits . getConst
 
-instance (Bits r, FromBits r (h (TargetOf x))) => FromBits r (Field h x) where
+instance (Bits r, KnownNat (BitWidth (h (TargetOf x))), FromBits r (h (TargetOf x))) => FromBits r (Field h x) where
   type BitWidth (Field h x) = BitWidth (h (TargetOf x))
   fromBits = Field . fromBits
   toBits = toBits . getField

--- a/src/Data/Extensible/Dictionary.hs
+++ b/src/Data/Extensible/Dictionary.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeFamilies, ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances, MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
-{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/src/Data/Extensible/Field.hs
+++ b/src/Data/Extensible/Field.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables, TypeFamilies #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE UndecidableSuperClasses, TypeInType #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE PolyKinds #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Extensible.Field


### PR DESCRIPTION
Solves #39 

I've explicitly added the `KnownNat (BitWidth (h (TargetOf x)))` constraint to  `FromBits`. Seems to be required for 9.10.1. Please, check that this make sense.

`TypeInType` is [getting deprecated](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/poly_kinds.html), switched to `PolyKinds` in some places which is supported by the GHC versions in `Tested-with`.